### PR TITLE
ARTEMIS-1129: Fixing tests after client all

### DIFF
--- a/artemis-core-client-all/pom.xml
+++ b/artemis-core-client-all/pom.xml
@@ -58,12 +58,43 @@
                         <filter>
                            <artifact>*:*</artifact>
                            <excludes>
+                              <exclude>INSTALL.html</exclude>
+                              <exclude>LICENSE</exclude>
+                              <exclude>README</exclude>
                               <exclude>META-INF/*.SF</exclude>
                               <exclude>META-INF/*.DSA</exclude>
                               <exclude>META-INF/*.RSA</exclude>
+                              <exclude>META-INF/ASL2.0</exclude>
+                              <exclude>META-INF/DEPENDENCIES.txt</exclude>
+                              <exclude>META-INF/LICENSE.txt</exclude>
+                              <exclude>META-INF/NOTICE.txt</exclude>
+                              <exlude>overview.html</exlude>
                            </excludes>
                         </filter>
+                        <filter>
+                           <artifact>org.jgroups:jgroups</artifact>
+                           <includes>
+                              <include>org/jgroups/**</include>
+                              <include>jg-magic-map.xml</include>
+                              <include>jg-protocol-ids.xml</include>
+                              <include>*.properties</include>
+                              <include>*.xsd</include>
+                           </includes>
+                        </filter>
                      </filters>
+                     <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                           <resource>META-INF/DEPENDENCIES</resource>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                           <addHeader>false</addHeader>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                           <resource>.txt</resource>
+                           <resource>features.xml</resource>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                     </transformers>
                      <relocations>
                         <relocation>
                            <pattern>org.apache.activemq</pattern>

--- a/artemis-jms-client-all/pom.xml
+++ b/artemis-jms-client-all/pom.xml
@@ -58,12 +58,43 @@
                         <filter>
                            <artifact>*:*</artifact>
                            <excludes>
+                              <exclude>INSTALL.html</exclude>
+                              <exclude>LICENSE</exclude>
+                              <exclude>README</exclude>
                               <exclude>META-INF/*.SF</exclude>
                               <exclude>META-INF/*.DSA</exclude>
                               <exclude>META-INF/*.RSA</exclude>
+                              <exclude>META-INF/ASL2.0</exclude>
+                              <exclude>META-INF/DEPENDENCIES.txt</exclude>
+                              <exclude>META-INF/LICENSE.txt</exclude>
+                              <exclude>META-INF/NOTICE.txt</exclude>
+                              <exlude>overview.html</exlude>
                            </excludes>
                         </filter>
+                        <filter>
+                           <artifact>org.jgroups:jgroups</artifact>
+                           <includes>
+                              <include>org/jgroups/**</include>
+                              <include>jg-magic-map.xml</include>
+                              <include>jg-protocol-ids.xml</include>
+                              <include>*.properties</include>
+                              <include>*.xsd</include>
+                           </includes>
+                        </filter>
                      </filters>
+                     <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                           <resource>META-INF/DEPENDENCIES</resource>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                           <addHeader>false</addHeader>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                           <resource>.txt</resource>
+                           <resource>features.xml</resource>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                     </transformers>
                      <relocations>
                         <relocation>
                            <pattern>org.apache.activemq</pattern>


### PR DESCRIPTION
To add ontop of the reduced-dependency.pom fix.

Clean up shaded jar
Ensure aggregated notice
Ensure correct license file, 
remove noise from jgroups dependency (taken from infinispans shade config)
remove other loose ends.